### PR TITLE
fix for lobid URL-Regex pattern

### DIFF
--- a/AcdhArcheAssets/uriNormRules.json
+++ b/AcdhArcheAssets/uriNormRules.json
@@ -15,7 +15,7 @@
   },
   {
      "name"    : "gnd-lobid",
-     "match"   : "^https?://lobid.org/gnd/([0-9]+)$",
+     "match"   : "^https?://lobid.org/gnd/?([-A-Z0-9]+)(?:/.*)?$",
      "replace" : "https://d-nb.info/gnd/\\1",
      "resolve" : "https://d-nb.info/gnd/\\1/about/lds.ttl",
      "format"  : "text/turtle"

--- a/AcdhArcheAssets/uriNormRules.json
+++ b/AcdhArcheAssets/uriNormRules.json
@@ -15,7 +15,7 @@
   },
   {
      "name"    : "gnd-lobid",
-     "match"   : "^https?://lobid.org/gnd/?([-A-Z0-9]+)(?:/.*)?$",
+     "match"   : "^https?://lobid.org/gnd/?([-A-Z0-9]+)(?:[.](?:json|rdf|ttl|nt))?$",
      "replace" : "https://d-nb.info/gnd/\\1",
      "resolve" : "https://d-nb.info/gnd/\\1/about/lds.ttl",
      "format"  : "text/turtle"


### PR DESCRIPTION
a lobid URL like `https://lobid.org/gnd/4113209-9` was not recognized